### PR TITLE
Expose headers in the response.

### DIFF
--- a/src/main/scala/github/gphat/datadog/HttpAdapter.scala
+++ b/src/main/scala/github/gphat/datadog/HttpAdapter.scala
@@ -91,7 +91,7 @@ class HttpAdapter(
 
   def doHttp(request: HttpRequest): Future[Response] = {
     (IO(Http) ? request).mapTo[HttpResponse].map({ res =>
-      Response(statusCode = res.status.intValue, res.entity.asString)
+      Response(statusCode = res.status.intValue, res.entity.asString, res.headers.toString)
     })
   }
 

--- a/src/main/scala/github/gphat/datadog/package.scala
+++ b/src/main/scala/github/gphat/datadog/package.scala
@@ -7,5 +7,5 @@ package object datadog {
     tags: Option[Seq[String]] = None, host: Option[String]
   )
 
-  case class Response(statusCode: Int, body: String)
+  case class Response(statusCode: Int, body: String, headers: String)
 }

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -21,7 +21,7 @@ class ClientSpec extends Specification {
 
     override def doHttp(request: HttpRequest): Future[Response] = {
       Future {
-        Response(500, "Internal Server Error")
+        Response(500, "Internal Server Error", "")
       }
     }
   }

--- a/src/test/scala/OkHttpAdapter.scala
+++ b/src/test/scala/OkHttpAdapter.scala
@@ -13,7 +13,7 @@ class OkHttpAdapter extends HttpAdapter {
 
   override def doHttp(request: HttpRequest) = {
     lastRequest = Some(request)
-    Future { Response(200, "Ok") }
+    Future { Response(200, "Ok", "") }
   }
 
   def getRequest = lastRequest


### PR DESCRIPTION
I have no idea what I'm doing...

Where the hell does `asString` come from?

This compiles, btw. And the headers property exists in that object. That was hard to track down...